### PR TITLE
Fix document ref population in post tests

### DIFF
--- a/tests/unit/mongo/models/posts.test.js
+++ b/tests/unit/mongo/models/posts.test.js
@@ -4,27 +4,26 @@ import User from "../../../../models/userModel.js";
 import Post from "../../../../models/postModel.js";
 import { TIMESTAMPS, MESSAGES, FILES, LINKS, TAGS } from "../../testConstants/postConstants.js";
 import { EMAILS, PASSWORDS, USERNAMES, HANDLES } from "../../testConstants/userConstants.js";
-import { POST_MODEL_NAME, VALIDATION_MESSAGES, POST_CONTENT_FIELDS } from "../../../../constants/postConstants.js";
+import { VALIDATION_MESSAGES, POST_CONTENT_FIELDS } from "../../../../constants/postConstants.js";
 import { USER_MODEL_NAME } from "../../../../constants/userConstants.js";
 
 beforeAll(() => setup());
 afterEach(() => cleanupPostCollection());
 afterAll(() => teardown());
 
-let testUserId;
+let testUser;
 
 /**
  * Setup test environment before any tests run.
  */
 const setup = async () => {
     await connectToMongoMemoryServer();
-    const testUser = await User.create({
+    testUser = await User.create({
         email: EMAILS.VALID_EMAIL,
         password: PASSWORDS.VALID_PASSWORD,
         username: USERNAMES.VALID_USERNAME_ALPHANUM,
         handle: HANDLES.VALID_HANDLE
     });
-    testUserId = testUser._id;
 };
 
 /**
@@ -48,19 +47,20 @@ describe("Post Model", () => {
     test("Create post with message", async () => {
         // Var
         const validPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE
         };
 
         // Test
         await Post.create(validPost);
-        const allPosts = await Post.find({});
+        const allPosts = await Post.find({}).populate(USER_MODEL_NAME);
         expect(allPosts.length).toEqual(1);
-        const foundPost = await allPosts[0].populate(USER_MODEL_NAME);
-        expect(foundPost.user._id).toEqual(testUserId);
+        const foundPost = allPosts[0];
+        expect(foundPost.user._id).toEqual(testUser._id);
         expect(foundPost.timestamp).toEqual(TIMESTAMPS.VALID_TIMESTAMP);
         expect(foundPost.message).toEqual(MESSAGES.VALID_MESSAGE);
+        expect(foundPost.user.email).toEqual(testUser.email);
     });
 
     test("Fails with user that does not exist", async () => {
@@ -81,7 +81,7 @@ describe("Post Model", () => {
     test("Fails with invalid timestamp type", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.INVALID_TIMESTAMP_IS_NUMBER,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
         };
@@ -95,7 +95,7 @@ describe("Post Model", () => {
     test("Fails with invalid timestamp format", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.INVALID_TIMESTAMP_FORMAT,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
         };
@@ -109,7 +109,7 @@ describe("Post Model", () => {
     test("Fails with invalid timestamp content", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.INVALID_TIMESTAMP_CONTENT,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
         };
@@ -123,7 +123,7 @@ describe("Post Model", () => {
     test("Fails when message is empty", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.INVALID_MESSAGE_EMPTY,
             [POST_CONTENT_FIELDS.linkContent]:LINKS.VALID_LINK
@@ -138,7 +138,7 @@ describe("Post Model", () => {
     test("Fails when message is too long", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.INVALID_MESSAGE_TOO_LONG,
         };
@@ -152,25 +152,26 @@ describe("Post Model", () => {
     test("Create post with files", async () => {
         // Var
         const validPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.fileContent]:FILES.VALID_FILES
         };
 
         // Test
         await Post.create(validPost);
-        const allPosts = await Post.find({});
+        const allPosts = await Post.find({}).populate(USER_MODEL_NAME);
         expect(allPosts.length).toEqual(1);
-        const foundPost = await allPosts[0].populate(USER_MODEL_NAME);
-        expect(foundPost.user._id).toEqual(testUserId);
+        const foundPost = allPosts[0];
+        expect(foundPost.user._id).toEqual(testUser._id);
         expect(foundPost.timestamp).toEqual(TIMESTAMPS.VALID_TIMESTAMP);
         expect([...foundPost.files]).toStrictEqual(FILES.VALID_FILES);
+        expect(foundPost.user.email).toEqual(testUser.email);
     });
 
     test("Fails when files not an array", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.fileContent]:FILES.INVALID_FILES_NOT_STRINGS
         };
@@ -184,7 +185,7 @@ describe("Post Model", () => {
     test("Fails when files contain invalid URL", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.fileContent]:FILES.INVALID_FILES_NOT_URL
         };
@@ -198,25 +199,26 @@ describe("Post Model", () => {
     test("Create post with links", async () => {
         // Var
         const validPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.linkContent]:LINKS.VALID_LINK
         };
 
         // Test
         await Post.create(validPost);
-        const allPosts = await Post.find({});
+        const allPosts = await Post.find({}).populate(USER_MODEL_NAME);
         expect(allPosts.length).toEqual(1);
-        const foundPost = await allPosts[0].populate(USER_MODEL_NAME);
-        expect(foundPost.user._id).toEqual(testUserId);
+        const foundPost = allPosts[0];
+        expect(foundPost.user._id).toEqual(testUser._id);
         expect(foundPost.timestamp).toEqual(TIMESTAMPS.VALID_TIMESTAMP);
         expect(foundPost.link).toEqual(LINKS.VALID_LINK);
+        expect(foundPost.user.email).toEqual(testUser.email);
     });
 
     test("Fails when links contains invalid URL", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.linkContent]:LINKS.INVALID_LINK_NO_TOP_DOMAIN
         };
@@ -230,7 +232,7 @@ describe("Post Model", () => {
     test("Fails when links contains invalid type", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.linkContent]:LINKS.INVALID_LINK_IS_NUMBER
         };
@@ -244,7 +246,7 @@ describe("Post Model", () => {
     test("Create Post with repost", async () => {
         // Var
         const validPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
         };
@@ -256,20 +258,24 @@ describe("Post Model", () => {
 
         // Test
         await Post.create(validPostWithRepost);
-        const allPosts = await Post.find({});
+        const allPosts = await Post.find({})
+            .populate(USER_MODEL_NAME)
+            .populate("repost");
         expect(allPosts.length).toEqual(2);
-        const foundPost = await allPosts[1].populate(POST_MODEL_NAME);
-        expect(foundPost.user._id).toEqual(testUserId);
+        const foundPost = allPosts[1];
+        expect(foundPost.user._id).toEqual(testUser._id);
         expect(foundPost.timestamp).toEqual(TIMESTAMPS.VALID_TIMESTAMP);
         expect(foundPost.message).toEqual(MESSAGES.VALID_MESSAGE);
         expect(foundPost.repost._id).toEqual(referencePost._id);
+        expect(foundPost.user.email).toEqual(testUser.email);
+        expect(foundPost.repost.message).toEqual(referencePost.message);
     });
 
     test("Fails when repost ref does not exist", async () => {
         // Var
         const unsavedPost = new Post();
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
             repost: unsavedPost._id
@@ -284,7 +290,7 @@ describe("Post Model", () => {
     test("Create Post with replyTo", async () => {
         // Var
         const validPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
         };
@@ -296,20 +302,24 @@ describe("Post Model", () => {
 
         // Test
         await Post.create(validPostWithRepost);
-        const allPosts = await Post.find({});
+        const allPosts = await Post.find({})
+            .populate(USER_MODEL_NAME)
+            .populate("replyTo");
         expect(allPosts.length).toEqual(2);
-        const foundPost = await allPosts[1].populate(POST_MODEL_NAME);
-        expect(foundPost.user._id).toEqual(testUserId);
+        const foundPost = allPosts[1];
+        expect(foundPost.user._id).toEqual(testUser._id);
         expect(foundPost.timestamp).toEqual(TIMESTAMPS.VALID_TIMESTAMP);
         expect(foundPost.message).toEqual(MESSAGES.VALID_MESSAGE);
         expect(foundPost.replyTo._id).toEqual(referencePost._id);
+        expect(foundPost.user.email).toEqual(testUser.email);
+        expect(foundPost.replyTo.message).toEqual(referencePost.message);
     });
 
     test("Fails when replyTo ref does not exist", async () => {
         // Var
         const unsavedPost = new Post();
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
             replyTo: unsavedPost._id
@@ -331,7 +341,7 @@ describe("Post Model", () => {
         };
         const altTestUser = await User.create(validUser);
         const validPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
             mentions: [altTestUser._id]
@@ -339,20 +349,21 @@ describe("Post Model", () => {
 
         // Test
         await Post.create(validPost);
-        const allPosts = await Post.find({});
+        const allPosts = await Post.find({}).populate(USER_MODEL_NAME);
         expect(allPosts.length).toEqual(1);
-        const foundPost = await allPosts[0].populate(USER_MODEL_NAME);
-        expect(foundPost.user._id).toEqual(testUserId);
+        const foundPost = allPosts[0];
+        expect(foundPost.user._id).toEqual(testUser._id);
         expect(foundPost.timestamp).toEqual(TIMESTAMPS.VALID_TIMESTAMP);
         expect(foundPost.message).toEqual(MESSAGES.VALID_MESSAGE);
         expect(foundPost.mentions[0]._id).toEqual(altTestUser._id);
+        expect(foundPost.user.email).toEqual(testUser.email);
     });
 
     test("Fails with mentioned user that does not exist", async () => {
         // Var
         const unsavedUser = new User();
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
             mentions: [unsavedUser._id]
@@ -367,7 +378,7 @@ describe("Post Model", () => {
     test("Create post with tags", async () => {
         // Var
         const validPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
             tags: TAGS.VALID_TAGS
@@ -378,7 +389,7 @@ describe("Post Model", () => {
         const allPosts = await Post.find({});
         expect(allPosts.length).toEqual(1);
         const foundPost = await allPosts[0];
-        expect(foundPost.user._id).toEqual(testUserId);
+        expect(foundPost.user._id).toEqual(testUser._id);
         expect(foundPost.timestamp).toEqual(TIMESTAMPS.VALID_TIMESTAMP);
         expect([...foundPost.tags]).toEqual(TAGS.VALID_TAGS);
     });
@@ -386,7 +397,7 @@ describe("Post Model", () => {
     test("Fails with invalid tags content", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
             tags: TAGS.INVALID_TAGS_IS_NUMBER
@@ -401,7 +412,7 @@ describe("Post Model", () => {
     test("Fails with invalid tags type", async () => {
         // Var
         const invalidPost = {
-            user: testUserId,
+            user: testUser._id,
             timestamp: TIMESTAMPS.VALID_TIMESTAMP,
             [POST_CONTENT_FIELDS.messageContent]:MESSAGES.VALID_MESSAGE,
             tags: TAGS.INVALID_TAGS_FORMAT


### PR DESCRIPTION
Issue: populate() being called against found documents directly.
Fix: Chain populate calls to find() functions.

Also changed global testUserId to testUser to be referenced in updated tests.

fixes #5 